### PR TITLE
Compile-time AST logging disabled by default

### DIFF
--- a/src/main/scala/org/expecty/Recorder.scala
+++ b/src/main/scala/org/expecty/Recorder.scala
@@ -20,4 +20,9 @@ import language.experimental.macros
 abstract class Recorder {
   val listener: RecorderListener[Boolean]
   def apply(recording: Boolean): Boolean = macro RecorderMacro.apply
+  def logged(recording: Boolean): Boolean = macro RecorderMacro.logged
+}
+
+trait CompileTimeLogging extends Recorder {
+  override def apply(recording: Boolean): Boolean = macro RecorderMacro.logged
 }

--- a/src/main/scala/org/expecty/RecorderMacro.scala
+++ b/src/main/scala/org/expecty/RecorderMacro.scala
@@ -15,7 +15,7 @@ package org.expecty
 
 import reflect.macros.Context
 
-class RecorderMacro[C <: Context](val context: C) {
+class RecorderMacro[C <: Context](val context: C, val logging:Boolean = false) {
   import context.universe._
 
   def apply(recording: Expr[Boolean]): Expr[Boolean] = {
@@ -130,13 +130,16 @@ class RecorderMacro[C <: Context](val context: C) {
   private[this] def getPosition(expr: Tree) = expr.pos.asInstanceOf[scala.reflect.internal.util.Position]
 
   private[this] def log(expr: Tree, msg: String) {
-    context.info(expr.pos, msg, force = false)
+    if(logging) context.info(expr.pos, msg, force = false)
   }
 }
 
 object RecorderMacro {
   def apply(context: Context)(recording: context.Expr[Boolean]): context.Expr[Boolean] = {
     new RecorderMacro[context.type](context).apply(recording)
+  }
+  def logged(context: Context)(recording: context.Expr[Boolean]): context.Expr[Boolean] = {
+    new RecorderMacro[context.type](context, true).apply(recording)
   }
 }
 


### PR DESCRIPTION
Can be enabled explicitly for recorder instance:

```
val expect = new Expecty() with CompileTimeLogging
```

Or, which is more convenient, per usage:

```
expect.logged { 1 == 2 }
```

Fixes #1
