### PR TITLE
Proper handling of package references

### DIFF
--- a/src/main/scala/org/expecty/RecorderMacro.scala
+++ b/src/main/scala/org/expecty/RecorderMacro.scala
@@ -93,6 +93,7 @@ class RecorderMacro[C <: Context](val context: C) {
     case Literal(_) => expr // don't record
     // don't record value of implicit "this" added by compiler; couldn't find a better way to detect implicit "this" than via point
     case Select(x@This(_), y) if getPosition(expr).point == getPosition(x).point => expr
+    case x:Select if x.symbol.isModule => expr // don't try to record the value of packages
     case _ => recordValue(recordSubValues(expr), expr)
   }
 


### PR DESCRIPTION
It makes possible to use several additional language constructs (tuples, case classes, java static methods, fully qualified class names, etc.) in expectations, which previously refused to compile with a messages like “inferred type arguments [scala.type] do not conform to method recordValue's type parameter bounds [U]”. 
